### PR TITLE
for in 循环阻塞主线程启动

### DIFF
--- a/Demo_07_展示dispatch_semaphore_t控制线程并发数量的用法/CYLDispatchSemaphoreTest/ViewController.m
+++ b/Demo_07_展示dispatch_semaphore_t控制线程并发数量的用法/CYLDispatchSemaphoreTest/ViewController.m
@@ -30,7 +30,7 @@
      *
      */
     NSMutableArray *array = [[NSMutableArray alloc] init];
-    for(int i = 0; i< 100000; ++i) {
+    for(int i = 0; i< 100; ++i) {
         dispatch_async_limit(queue, 1, ^{
             /*
              *
@@ -50,7 +50,7 @@
              *因此可安全地进行更新
              *
              */
-            NSLog(@"🔴%@",[NSThread currentThread]);
+            NSLog(@"%d 🔴%@", i, [NSThread currentThread]);
             [array addObject:[NSNumber numberWithInt:i]];
             /*
              *
@@ -96,7 +96,8 @@ void dispatch_async_limit(dispatch_queue_t queue,NSUInteger limitSemaphoreCount,
     dispatch_async(receiverQueue, ^{
         //可用信号量后才能继续，否则等待
         dispatch_semaphore_wait(limitSemaphore, DISPATCH_TIME_FOREVER);
-        dispatch_async(queue, ^{
+        
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), queue, ^{
             !block ? : block();
             //在该工作线程执行完成后释放信号量
             dispatch_semaphore_signal(limitSemaphore);


### PR DESCRIPTION
demo7 中，使用了实战优化，但是实际仍然卡在了App启动界面。

个人理解：
for in 开销过多，而紧随着的block很快，导致误以为优化失败。其实优化成功，但是此处block太快，for in循环反而太多，导致效果不明显。
这里减少了for in 次数，延长block 执行时间，就可以明显观察到未被阻塞。但是如果要优化，还是需要加开for in 的情况下，才会效果明显吧。